### PR TITLE
Fixed out-of-app-context error for sqlalchemy database.

### DIFF
--- a/src/web/app.py
+++ b/src/web/app.py
@@ -15,7 +15,8 @@ app.secret_key = FLASK_SECRET_KEY
 # Load the database.
 db = SQLAlchemy(app)
 from models import *
-db.create_all()
+with app.app_context():
+	db.create_all()
 
 # Authentication.
 from authentication import *


### PR DESCRIPTION
Moved the call to db.create_all() inside a with app.appcontext() clause. The error only affected windows machines so far.